### PR TITLE
Add AutoApply scaffold

### DIFF
--- a/AUTOAPPLY_CODEX_PROMPT.md
+++ b/AUTOAPPLY_CODEX_PROMPT.md
@@ -1,0 +1,33 @@
+# ROLE
+You are Codex acting as a senior full-stack extension engineer…
+
+## GLOBAL RULES
+1. …
+
+## GLOSSARY
+* **Toast**: 1-second Chrome notification per NOTIFY_SCHEMA.md  
+…
+
+## FILE/TREE
+<insert tree>
+
+## MODULE: recorder.ts  (REQ R1, R4, R5, R13)
+```ts
+// ────────────────────────────────────────────────
+// recorder.ts — Captures user interactions on Taleo
+// WHY THIS FILE EXISTS:
+//   • Implements R1 (capture actions)
+//   • Feeds replayer.ts & flowchart-ui.ts
+// Dependencies: storage.ts (saveAction), notify.ts (toastInfo)
+// ────────────────────────────────────────────────
+
+// 🔹 STEP 0: bootstrap mutation observer to watch DOM clicks.
+```
+
+*commentary continues…*
+
+<!-- Repeat for every module, referencing schemas & guides -->
+
+## SELF-QC
+
+*Check all boxes in QC_CHECKLIST.md before returning generated code.*

--- a/COMMENT_GUIDE.md
+++ b/COMMENT_GUIDE.md
@@ -1,0 +1,23 @@
+### Line-by-Line Pedagogical Comment Standard
+
+```ts
+// 🔹 STEP 1: Query the button that submits the job application.
+// We use a CSS attribute selector because Taleo renders
+// dynamic IDs but stable `data-apply-btn` attributes.
+const submitBtn = document.querySelector('[data-apply-btn]') as HTMLButtonElement;
+
+/*
+ *  WHY THIS MATTERS:
+ *  Non-tech readers: selectors let the script "see" the HTML element.
+ *  Future change: if Taleo alters attribute names, adjust here.
+ */
+submitBtn?.click();  // 🔸 ACTION: simulate user click.
+```
+
+**Rules**
+
+1. **Emoji bullets** (`🔹`, `🔸`, `⚠️`) → quick visual scanning.
+2. **Blank line** between logical blocks.
+3. **Caps “WHY THIS MATTERS”** section for every non-trivial line.
+4. Comment stubs:
+   `/* --- FUTURE:MOUSE_REPLAY: captureMove(event) --- */`

--- a/DEBUG_SPEC.md
+++ b/DEBUG_SPEC.md
@@ -1,0 +1,13 @@
+### Log Levels
+| Level | Color | Example |
+|-------|-------|---------|
+| INFO  | grey  | "Tab delay applied: 374 ms" |
+| WARN  | yellow| "Selector '.foo' not found, retry 1/3" |
+| ERROR | red   | "Unhandled promise rejection in recorder.ts:42" |
+
+*Format*  
+```json
+{"ts":"2025-07-01T10:21:34.123Z","level":"INFO","module":"replayer","msg":"Waited 9.1s for navigation"}
+```
+
+*Store first in IndexedDB; batch-flush to CSV/Sheets when replayer stops.*

--- a/ERROR_CATALOG.md
+++ b/ERROR_CATALOG.md
@@ -1,0 +1,5 @@
+| Code | Trigger | Toast Message | Debug Action |
+|------|---------|---------------|--------------|
+| E01  | Selector missing | "Element not found → halted" | Log last-5 steps JSON |
+| E02  | Captcha present | "Solve captcha & press Continue" | Pause replayer |
+| E03  | Excel read fail | "config.xlsx unreadable" | Bubble up & stop |

--- a/MODULE_MAP.md
+++ b/MODULE_MAP.md
@@ -1,0 +1,16 @@
+```mermaid
+graph TD
+  A[popup.ts] -->|starts| B(recorder.ts)
+  B --> C(storage.ts)
+  C --> D[IndexedDB]
+  B --> E(replayer.ts)
+  E --> F(flowchart-ui.ts)
+  F --> G[Mermaid DOM]
+  E --> H(captcha-handler.ts)
+  H --> E
+  %% FUTURE
+  E -.-> I(mouse-replay.ts):::future
+  E -.-> J(multi-tab-manager.ts):::future
+
+classDef future stroke-dasharray: 5 5;
+```

--- a/NOTIFY_SCHEMA.md
+++ b/NOTIFY_SCHEMA.md
@@ -1,0 +1,15 @@
+### 1-Sec Toast Contract (Chrome `notifications` API)
+
+| Field | Type | Example |
+|-------|------|---------|
+| `id`  | string | `"autoapply-step-12"` |
+| `title` | string | `"AutoApply • Step 12"` |
+| `message` | string | `"Clicked ‘Apply’ button"` |
+| `iconUrl` | string | `"icons/64.png"` |
+| `silent` | boolean | `true` |
+
+💡 *Codex must call `chrome.notifications.create()` with these fields every time it:*  
+- clicks a CTA  
+- fills a form section  
+- waits for page navigation  
+- throws an error (then duration = 5 s, red icon)

--- a/PROMPT_BLUEPRINT.md
+++ b/PROMPT_BLUEPRINT.md
@@ -1,0 +1,37 @@
+# Blueprint: Anatomy of `AUTOAPPLY_CODEX_PROMPT.md`
+
+1. **Meta-Role & Global Directives**  
+   *Why?* Orient Codex in one shot; prevents drift.
+
+2. **Glossary** (Taleo, toast, Excel config…)  
+   *Why?* Codex token disambiguation.
+
+3. **High-Level Spec Recap** (links back to REQ IDs)  
+   *Why?* Traceability.
+
+4. **File/Folder Structure** (tree)  
+   *Why?* Guides Codex output paths.
+
+5. **Coding Standards** (TypeScript, ESLint, free libs only)  
+   *Why?* Enforce consistency.
+
+6. **Notification + Debug Contract** (import from NOTIFY_SCHEMA & DEBUG_SPEC)  
+   *Why?* Single source of truth.
+
+7. **Module-by-Module Instructions**  
+   *Each module block*: purpose, inputs, outputs, references, future stubs.
+
+8. **Commenting Mandate**  
+   Reference COMMENT_GUIDE.
+
+9. **Edge-Case Handling**  
+   Pull text from ERROR_CATALOG.
+
+10. **Future-Stub Tags**  
+    e.g. `/* --- FUTURE:MOUSE_REPLAY --- */`
+
+11. **Self-QC Reminder**  
+    Point Codex to QC_CHECKLIST.
+
+12. **“Begin Code Generation” Marker**  
+    Explicit boundary where Codex starts emitting files.

--- a/QC_CHECKLIST.md
+++ b/QC_CHECKLIST.md
@@ -1,0 +1,5 @@
+- [ ] Every REQ ID has at least one instruction in `AUTOAPPLY_CODEX_PROMPT.md`
+- [ ] Comment examples follow COMMENT_GUIDE
+- [ ] Notification spec implemented
+- [ ] All edge cases from ERROR_CATALOG referenced
+- [ ] Future stubs tagged & commented

--- a/REQ_MATRIX.md
+++ b/REQ_MATRIX.md
@@ -1,0 +1,16 @@
+| ID | Requirement | Priority | Origin | Future-Flag |
+|----|-------------|----------|--------|-------------|
+| R1 | Record DOM actions on Taleo (click, input, keypress, timestamps, URL) | MUST | Original |  |
+| R2 | Filter after 5 apps → retain ≥3-repeat steps | MUST | Original |  |
+| R3 | Human-like random delays via Excel config | MUST | Original |  |
+| R4 | 1-sec toast notifications at every major action | MUST | Improvement-2 |  |
+| R5 | Line-by-line pedagogical comments | MUST | Improvement-3 |  |
+| R6 | Stubs: Workday, SuccessFactors, Greenhouse | SHOULD | Original | FUTURE |
+| R7 | Stubs: mouse coordinates replay | SHOULD | Original | FUTURE |
+| R8 | Error handler: toast + last-5-steps; halt | MUST | Original |  |
+| R9 | Captcha pause / continue | MUST | Original |  |
+| R10 | Storage: IndexedDB (default) + CSV / Sheets export | MUST | Original |  |
+| R11 | Multi-tab execution stub | SHOULD | Original | FUTURE |
+| R12 | AES-GCM encryption stub | SHOULD | Original | FUTURE |
+| R13 | Prompt must explain *why* every directive exists | MUST | Improvement-1 |  |
+| R14 | Commented code placeholders for every future feature | MUST | Improvement-4 |  |

--- a/ROADMAP_STUBS.md
+++ b/ROADMAP_STUBS.md
@@ -1,0 +1,5 @@
+| Stub Tag | Future Feature | File placeholder | Data-Model Impact |
+|----------|----------------|------------------|-------------------|
+| FUTURE:MOUSE_REPLAY | Capture & replay mouse moves | `mouse-replay.ts` | Add `x`,`y` to action schema |
+| FUTURE:MULTI_TAB | Parallel apps per tab | `multi-tab-manager.ts` | Queue of tabIds |
+| FUTURE:ENCRYPTION | AES-GCM for PII | `crypto.ts` | Encrypt fields before storage |

--- a/UX_WIREFRAME.md
+++ b/UX_WIREFRAME.md
@@ -1,0 +1,12 @@
++-------------------------------------------------+
+| Popup (90×420)                                  |
+|                                                 |
+| [Activate / Stop]  ⟵ id="btn-activate"          |
+| ------------------------------------------------ |
+| Status: ••• Running (Step 7)                    |
+|                                                 |
+| [Flowchart ▶]  ⟵ opens flowchart-ui.html        |
+|                                                 |
++-------------------------------------------------+
+
+Toast appears bottom-right, fades after 1 s (info) or 5 s (error).


### PR DESCRIPTION
## Summary
- add requirements matrix and spec docs for the AutoApply extension
- add blueprint and style guides for future Codex generation
- include debug, notification and error handling specs
- provide roadmap stubs and QC checklist

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68638c4fa0308332ba6f9e432df8b79f